### PR TITLE
Prevent launching Promise.all on empty array

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -176,7 +176,7 @@ export default class Queue extends EventEmitter {
 
       promises.push(Promise.resolve(promise()));
     });
-
+    if(promises.length == 0) return;
     return Promise.all(promises)
       .then(values => {
         for (let output of values) this.emit("resolve", output);


### PR DESCRIPTION
This prevents launching finalize which decreases this.currentlyHandled below 0 causing this.options.concurrent irrelevant